### PR TITLE
5 fix home and GitHub links in header

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -136,13 +136,3 @@ a:hover {
 .links a {
   text-decoration: none;
 }
-
-@media screen and (max-width: 1100px) {
-  .grid {
-    grid-template-columns: 1fr;
-  }
-}
-
-.links a {
-  text-decoration: none;
-}


### PR DESCRIPTION
Home and github links now stick to right side of header in a column, across screensizes